### PR TITLE
Austritt

### DIFF
--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -1094,11 +1094,11 @@
     </gebiet>
     <gebiet type="Bezirk" name="Regierungsbezirk Arnsberg" gs="05900000">
       <gebiet type="Kreisfreie Stadt" name="Bochum" gs="05911000" localpirates="http://piratenbochum.de/">
-        <parlament name="Stadtrat" seats="84" ris="https://session.bochum.de/bi/infobi.php">
+<!--        <parlament name="Stadtrat" seats="84" ris="https://session.bochum.de/bi/infobi.php">
           <mandat type="pirat">Andre Kasper</mandat>
           <fraktion type="none" />
           <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 2,1% der Stimmen erreicht. Nach dem Austritt einer Mandatsträgerin aus der Piratenpartei wurde im April 2015 die bis dahin bestehende Gruppe aufgelöst.</story>
-        </parlament>
+        </parlament> -->
         <gebiet type="Stadtbezirk" name="Mitte" localkey="1">
           <parlament name="Bezirksvertretung" seats="19" ris="https://session.bochum.de/bi/kp0040.php?__kgrnr=103973">
             <mandat type="pirat">Jannis Mehring</mandat>

--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -1001,14 +1001,14 @@
           <fraktion type="none" />
           <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 1,6% der Stimmen erreicht.</story>
         </parlament>
-        <gebiet type="Stadt" name="Beckum" gs="05570008">
+<!--        <gebiet type="Stadt" name="Beckum" gs="05570008">
           <parlament name="Stadtrat" seats="38" ris="https://www.beckum.de/sessionnet/sessionnetbi/infobi.php">
             <oa url="http://openantrag.de/beckum" />
             <mandat type="pirat" email="michael.ortner@piratenpartei-nrw.de">Michael Ortner</mandat>
             <fraktion type="none" />
             <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 2,6% der Stimmen erreicht.</story>
           </parlament>
-        </gebiet>
+        </gebiet> -->
         <gebiet type="Stadt" name="Sendenhorst" gs="05570040">
           <parlament name="Stadtrat" seats="26" ris="https://www.sendenhorst.de/rais/">
             <mandat type="pirat">Thomas Lohmann</mandat>


### PR DESCRIPTION
http://www.die-glocke.de/lokalnachrichten/kreiswarendorf/beckum/Pirat-Ortner-wechselt-zu-den-Liberalen-5e83d7ff-c61d-4d69-ba0e-d5b1e9e5a4e1-ds