### PR TITLE
Aktualisierung Sachsen

### DIFF
--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -2126,18 +2126,6 @@
         <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 2,0% der Stimmen erreicht.</story>
       </parlament>
     </gebiet>
-    <gebiet type="Landkreis" name="Landkreis Görlitz" gs="14626000" localpirates="http://piraten-goerlitz.de/">
-      <gebiet type="Stadt" name="Görlitz" gs="14626110">
-        <parlament name="Stadtrat" seats="38" ris="https://sitzungsdienst.kin-sachsen.de/goerlitz/index.php">
-          <mandat type="pirat" email="carolin.mahn-gauseweg@piraten-sachsen.de">Carolin Mahn-Gauseweg</mandat>
-          <fraktion type="gemeinsam" name="BfG/Grüne/Piraten">
-            <partner name="Bürger für Görlitz" partei="FW/UWG/etc." num="8" />
-            <partner partei="GRÜNE" num="2" />
-          </fraktion>
-          <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 3,0% der Stimmen erreicht.</story>
-        </parlament>
-      </gebiet>
-    </gebiet>
     <gebiet type="Landkreis" name="Landkreis Meißen" gs="14627000" localpirates="http://piraten-meissen.de/">
       <parlament name="Kreistag" seats="86">
         <mandat type="pirat" email="soeren.skalicks@piraten-meissen.de">Sören Skalicks</mandat>


### PR DESCRIPTION
Carolin Mahn-Gauseweg http://www.sz-online.de/nachrichten/wechsel-bei-den-piraten-3544430.html

Die Datenbasis ist wirklich veraltert. Gefühlt sind 20% der Mandatsträger keine Piraten mehr. Ist leider sehr schwer das zu belegen. Hier gehört wirklich mal ausgemistet.