### PR TITLE
Update piratenmandate.xml

### DIFF
--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -1293,9 +1293,7 @@
           <parlament name="Stadtrat" seats="52" ris="http://www.unna.de/ratsinfo/index.php">
             <oa url="http://openantrag.de/unna-stadt" />
             <mandat type="pirat">Christian Ross</mandat>
-            <mandat type="pirat">Christoph Tetzner</mandat>
-            <fraktion type="piraten" url="http://piratenfraktion-unna.de/" />
-            <story source="https://blog.piratenpartei-nrw.de/unna/2014/11/24/piratenfraktion-in-unna-loest-sich-auf/">Bei der Kommunalwahl am 25. Mai 2014 wurden 3,5% der Stimmen erreicht. Es bestand zunächst eine Fraktion, die vorübergehend aufgelöst war. Seit dem Nachrücken eines Piratenvertreters besteht sie wieder.</story>
+            <story source="https://piratenpartei-unna.de/2016/11/17/piratenpartei-beendet-zusammenarbeit-mit-christoph-tetzner/">Bei der Kommunalwahl am 25. Mai 2014 wurden 3,5% der Stimmen erreicht. Es bestand zunächst eine Fraktion, die vorübergehend aufgelöst war. Seit dem Austritt Christoph Tetzners aus der Piratenpartei ist die Fraktion endgültig beendet.</story>
           </parlament>
         </gebiet>
       </gebiet>


### PR DESCRIPTION
Christoph Tetzner hat am 21.10.2016 seinen Austritt aus der Piratenpartei erklärt, hat aber sein Ratsmandat bis heute behalten. Somit sitzt nur noch ein Pirat im Unnaer Stadtrat