### PR TITLE
Aktualisierung Krefeld und Mühlheim

### DIFF
--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -443,13 +443,6 @@
           </parlament>
         </gebiet>
       </gebiet>
-      <gebiet type="Kreisfreie Stadt" name="Krefeld" gs="05114000" localpirates="http://www.seidenstadt-piraten.de/">
-        <parlament name="Stadtrat" seats="58" ris="http://www.ratsportal.krefeld.de/">
-          <mandat type="pirat">Peter Klein</mandat>
-          <fraktion type="none" />
-          <story source="http://www.wz-newsline.de/lokales/krefeld/uwg-wird-wieder-zur-fraktion-1.1895919">Bei der Kommunalwahl am 25. Mai 2014 wurden 2,0% der Stimmen erreicht. Es wurde eine gemeinsame Gruppe mit einem Stadtverordneten der PARTEI gegründet, die im März 2015 von Seiten der PARTEI wieder aufgekündigt würde.</story>
-        </parlament>
-      </gebiet>
       <gebiet type="Kreisfreie Stadt" name="Mönchengladbach" gs="05116000" localpirates="https://wiki.piratenpartei.de/NRW:M%C3%B6nchengladbach">
         <gebiet type="Stadtbezirk" name="Ost" arbkey="1">
           <parlament name="Bezirksvertretung" seats="19" ris="https://www.itk-rheinland.de/ratsinfo/moenchengladbach/Committee.html?orgid=115&amp;single=1&amp;o=1&amp;oc=1&amp;ob=1#current">
@@ -458,14 +451,6 @@
             <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 2,6% der Stimmen erreicht.</story>
           </parlament>
         </gebiet>
-      </gebiet>
-      <gebiet type="Kreisfreie Stadt" name="Mülheim an der Ruhr" gs="05117000" localpirates="http://www.piratenpartei-muelheim.de">
-        <parlament name="Stadtrat" seats="54" ris="http://ratsinfo.muelheim-ruhr.de/buerger/allris.net.asp">
-          <oa url="http://openantrag.de/muelheim-ruhr" />
-          <mandat type="pirat">Carsten Trojahn</mandat>
-          <fraktion type="none" />
-          <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 1,7% der Stimmen erreicht.</story>
-        </parlament>
       </gebiet>
       <gebiet type="Kreisfreie Stadt" name="Solingen" gs="05122000" localpirates="https://blog.piratenpartei-nrw.de/solingen/">
         <parlament name="Stadtrat" seats="52" ris="http://www2.solingen.de/C12572F80037DB19/0/2692B6EF8295A46CC1257392004927E8?OpenDocument">


### PR DESCRIPTION
Auf Nachfrage per Email teilten Peter Klein und Carsten Trojahn mit, sie sind keine Mitglieder der Piraten mehr.