### PR TITLE
Aktualisierung Lepper und Lohmann

### DIFF
--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -874,17 +874,10 @@
       </gebiet>
       <gebiet type="Landkreis" name="Kreis Warendorf" gs="05570000" localpirates="http://www.piratenpartei-warendorf.de/">
         <parlament name="Kreistag" seats="56" ris="http://www.kreis-warendorf.de/w1/sessionnet2014/bi/infobi.php">
-          <mandat type="pirat" email="pia.hermans@piratenpartei-warendorf.de">Pia Hermans</mandat>
+          <mandat type="pirat">Martin Lepper</mandat>
           <fraktion type="none" />
           <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 1,6% der Stimmen erreicht.</story>
         </parlament>
-        <gebiet type="Stadt" name="Sendenhorst" gs="05570040">
-          <parlament name="Stadtrat" seats="26" ris="https://www.sendenhorst.de/rais/">
-            <mandat type="pirat">Thomas Lohmann</mandat>
-            <fraktion type="none" />
-            <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 3,9% der Stimmen erreicht.</story>
-          </parlament>
-        </gebiet>
       </gebiet>
     </gebiet>
     <gebiet type="Bezirk" name="Regierungsbezirk Detmold" gs="05700000">


### PR DESCRIPTION
Herr Lohmann ist laut Ratsdokumenten am 03.05.2018 ausgeschieden. Sein Nachrücker gehört einer anderen Gruppierung an. Pia Hermans wurde durch Herrn Lepper am 07.11.2018 beerbt.