### PR TITLE
Update Bonn

### DIFF
--- a/piratenmandate.xml
+++ b/piratenmandate.xml
@@ -662,17 +662,15 @@
         </gebiet>
       </gebiet>
       <gebiet type="Kreisfreie Stadt" name="Bonn" gs="05314000" localpirates="https://piratenpartei-bonn.de/">
-        <parlament name="Stadtrat" seats="86" ris="http://www2.bonn.de/bo_ris/ris_sql/agm_index.asp">
+        <parlament name="Stadtrat" seats="86" ris="https://www.bonn.sitzung-online.de/">
           <oa url="http://openantrag.de/bonn" />
           <mandat type="pirat">Felix Kopinski</mandat>
-          <mandat type="pirat">Dr. Carsten Euwens</mandat>
-          <fraktion type="gemeinsam" name="Die Sozialliberalen" url="https://www.diesozialliberalen.de/" email="info@diesozialliberalen.de">
-              <partner partei="parteilos" num="1" />
-          </fraktion>
+          <mandat type="pirat">Michael Wisniewski</mandat>
+          <fraktion type="gruppe" name="Piraten" url="https://www.kommunalpiraten-bonn.de/" email="info@kommunalpiraten-bonn.de" />
           <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 2,2% der Stimmen erreicht.</story>
         </parlament>
         <gebiet type="Stadtbezirk" name="Bonn" arbkey="1">
-          <parlament name="Bezirksvertretung" seats="19" ris="http://www2.bonn.de/bo_ris/ris_sql/agm_index.asp?e_register=2&amp;e_content=3502&amp;e_gre_id=2&amp;e_p_p_id=10&amp;e_gre_art=Gremien&amp;e_caller=hbr_gremien_result">
+          <parlament name="Bezirksvertretung" seats="19" ris="https://www.bonn.sitzung-online.de/gr020?GRLFDNR=2">
             <mandat type="pirat">Christoph Grenz</mandat>
             <fraktion type="none" />
             <story>Bei der Kommunalwahl am 25. Mai 2014 wurden 2,7% der Stimmen erreicht.</story>


### PR DESCRIPTION
- Michael Wisniewski rückt für Carsten Euwens nach
- Auflösung der Fraktion "Die Sozialliberalen" (März 2020)
- URLs von neuem RIS eingetragen